### PR TITLE
Updated requirements.txt to allow Kivy to build on MacOS 26.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ kivy_garden
 *.apk
 *.dmg
 *.exe
+
+# MacOS
+.DS_Store

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,4 @@ https://github.com/kivymd/KivyMD/archive/5ff9d0de78260383fae0737716879781257155a
 kivy-garden.graph==0.4.0
 mapview==1.0.6
 plyer==2.1.0
+pyobjus==1.2.4

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 platformdirs==4.3.6
-kivy==2.3.0
+kivy==2.3.1
 https://github.com/kivymd/KivyMD/archive/5ff9d0de78260383fae0737716879781257155a8.zip
 kivy-garden.graph==0.4.0
 mapview==1.0.6


### PR DESCRIPTION
First, I just bought an Atom 2 and was quite annoyed by the inability to access the telemetry data - so THANK YOU FOR WRITING THIS!

That said, the MacOS release package crashes on launch on my MBP running MacOS 26.2.

Downloading the src, I discovered pip was failing to install Kivy, so I tried updating the Kivy version from 2.3.0 to 2.3.1 - and the install worked.

Thanks again for writing this! I plan on exploring the code a good bit, my ultimate hope is to be able to generate a way to overlay the telemetry data over a video of the flight itself - but we'll see. While I'm an experienced C programmer my knowledge of python is fairly minimal.